### PR TITLE
updating from upstream

### DIFF
--- a/tests/AgDatabaseMove.Unit/SmoFacadeListenerTest.cs
+++ b/tests/AgDatabaseMove.Unit/SmoFacadeListenerTest.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace AgDatabaseMove.Unit
+{
+  public class SmoFacadeListenerTest
+  {
+
+    /// <summary>
+    /// Tests for Listener.SplitDomainAndPort()
+    /// </summary>
+
+    private const string DOMAIN = "abc.def.ghi";
+    private const string HOST = "abc";
+    private const string PORT = ",123";
+    private const string NAMED_INSTANCE = "\\SQL";
+    private const string BAD_PORT = ":123";
+    private const string BAD_NAMED_INSTANCE = "SQL";
+
+    // {input, expectedDomain, expectedPort (can be null)}
+    public static IEnumerable<object[]> ValidPorts => new List<object[]> {
+      new object[] { DOMAIN, DOMAIN, null },
+      new object[] { $"{DOMAIN}{PORT}", DOMAIN, PORT },
+      new object[] { $"{DOMAIN}{NAMED_INSTANCE}", DOMAIN, NAMED_INSTANCE },
+
+      new object[] { HOST, HOST, null },
+      new object[] { $"{HOST}{PORT}", HOST, PORT },
+      new object[] { $"{HOST}{NAMED_INSTANCE}", HOST, NAMED_INSTANCE }
+    };
+
+    [Theory, MemberData(nameof(ValidPorts))]
+    public void ValidPortTests(string input, string expectedDomain, string expectedPort=null)
+    {
+      var (domain, port) = SmoFacade.Listener.SplitDomainAndPort(input);
+      Assert.Equal(domain, expectedDomain);
+      Assert.Equal(port, expectedPort);
+    }
+    
+    // {input, expectedDomain, expectedPort (can be null)}
+    public static IEnumerable<object[]> InvalidPorts => new List<object[]> {
+      new object[] { $"{DOMAIN}{BAD_PORT}", $"{DOMAIN}{BAD_PORT}", null },
+      new object[] { $"{DOMAIN}{BAD_NAMED_INSTANCE}", $"{DOMAIN}{BAD_NAMED_INSTANCE}", null },
+
+      new object[] { $"{HOST}{BAD_PORT}", $"{HOST}{BAD_PORT}", null },
+      new object[] { $"{HOST}{BAD_NAMED_INSTANCE}", $"{HOST}{BAD_NAMED_INSTANCE}", null },
+    };
+
+    [Theory, MemberData(nameof(InvalidPorts))]
+    public void InvalidPortTests(string input, string expectedDomain, string expectedPort=null)
+    {
+      var (domain, port) = SmoFacade.Listener.SplitDomainAndPort(input);
+      Assert.Equal(domain, expectedDomain);
+      Assert.Equal(port, expectedPort);
+    }
+
+
+    /// <summary>
+    /// Tests for Listener.GetPreferredPort()
+    /// </summary>
+
+    private const string IPort = ",123";
+    private const string INamed = "\\SQL";
+
+    private const string LPort = ",321";
+    private const string LNamed = "\\LQS";
+   
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData(null, LPort, LPort)]
+    [InlineData(null, LNamed, LNamed)]
+    [InlineData(IPort, null, IPort)]
+    [InlineData(IPort, LPort, IPort)]
+    [InlineData(IPort, LNamed, IPort)]
+    [InlineData(INamed, null, INamed)]
+    [InlineData(INamed, LPort, LPort)]
+    [InlineData(INamed, LNamed, INamed)]
+    public void PortPreferenceTests(string instancePortOrNamedInstance, string listenerPortOrNamedInstance, string expectedResult)
+    {
+      var preferredPortOrNamedInstance = SmoFacade.Listener.GetPreferredPort(instancePortOrNamedInstance, listenerPortOrNamedInstance);
+      Assert.Equal(preferredPortOrNamedInstance, expectedResult);
+    }
+
+  }
+}


### PR DESCRIPTION
fix(linux_dns_issue): Re-trying DNS lookup of instance name after appending the domain from AG listener (#57)

* fix(linux_dns_issue): POC

* fix(linux_dns_issue): compatible with dotnet 4.7 + summary docs

* fix(linux_dns_issue): whitespace

* fix(linux_dns_issue): more whitespace

* feat(linux_dns_issue): Handling ports and named instances

* refactor(linux_dns_issue): some renames + removed the  check to see if 'agReplicaInstanceName' is already FQDN

* fix(linux_dns_issue): moved named instance handling to 'SplitDomainPort()' + PR suggestions

* refactor(linux_dns_issue): PR suggestions + comments + renames

* test(Listener): New tests for 'SplitDomainAndPort()'

* refactor(Listener): Moving using statements back inside namespace

* fix(linux_dns_issue): prefer adding back ports over named instances

* refactor(linux_dns_issue): renames

* refactor(port preference): simplified if conditions

* refactor(Listener.cs): PR suggestions for renames and test data